### PR TITLE
Asa - Add Captain Section, Define Captain Selection and Roles - 20260315

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -181,7 +181,7 @@ officer or captain.
   1. The officer or captain stepping down must provide a minimum of two weeks's notice that they are stepping down.
   2. Upon notice of an officer stepping down, the Executive Board must begin electing a replacement officer using the rules in the [Elections](#13-elections) section.
   3. Upon notice of a captain stepping down, the Executive Board must appoint a new captain as defined in the [Captains](#6-captains) section.
-  4. An interim officer may be appointed by the President and Vice President as needed until the officer position is officially filled
+  4. An interim officer or captain may be appointed by the President and Vice President as needed until the officer or captain position is officially filled
 * In the event an officer or captain is not fulfilling their duties as outlined by the President and in the [Officers](#5-officers) section or the [Captains](#6-captains) section respectively, they meet grounds for dismissal from their officer position.
   * The President and Vice President may issue a verbal or written warning outlining the officer or captain in question’s failed duties and other misconducts as applicable.
   * After a warning is issued, the officer or captain in question will begin a two-week probationary period where they can address the grievances cited in the warning.

--- a/constitution.md
+++ b/constitution.md
@@ -172,7 +172,7 @@ efforts and discuss opportunities.
     1. The Social Chair shall plan, organize, and execute at least 2 social and fundraising events per semester.
     2. The Social Chair will report to the Event Planner unless otherwise decided by the President.
 * Filling vacancies:
-  * If there is a sudden vacancy for an officer position, nominations must be taken at the meeting following the vacancy. Refer to the rules in the [Elections] section(#13-elections).
+  * If there is a sudden vacancy for an officer position, nominations must be taken at the meeting following the vacancy. Refer to the rules in the [Elections](#13-elections) section.
 
 ## 8. Removal/Replacement of Officers and Captains <a name="8-removalreplacement-of-officers-and-captains"></a>
 

--- a/constitution.md
+++ b/constitution.md
@@ -133,22 +133,23 @@ efforts and discuss opportunities.
     4. The goal of the Tech Director will be managing and maintaining the technical resources of the club to facilitate trainings, competitions, and club image.
 
 ## 6. Captains <a name="6-captains"></a>
-* Following elections and at least one week prior to the end of the Spring semester, the Executive Board shall appoint Offensive, Defensive, and CTF Captains for the upcoming academic year.
-* Newly appointed captains fully assume their roles and responsibilities at the end of the Spring semester.
 * Active members may be appointed to captain positions by a majority vote of the Executive Board.
+* Following elections and at least one week prior to the end of the Spring semester, the Executive Board shall appoint Offensive, Defensive, and CTF Captains for the upcoming academic year by a majority vote.
+* The Executive Board shall solicit recommendations for new Captains from the outgoing Captains, and shall also accept statements of interest from active members.
+* Newly appointed captains fully assume their roles and responsibilities at the end of the Spring semester.
 * The President may appoint active members to a captain position without a vote with consent from the Vice President.
 * Active members may hold a single officer or captain position at a time.
 * Captains may hold an Officer position with the approval of both the current President and club Advisor.
-
 * Captain Positions:
   * Offensive, Defensive, and CTF Captains
     1. Each captain position can only be held by one individual, no one may hold multiple captain positions simultaneously.
     2. The Offensive and Defensive Captains will lead the CPTC and CCDC competition teams respectively, as well as any other non-CTF cybersecurity competitions unless otherwise decided by the President.
-    3. The CTF Captain will identify and promote CTF competitions throughout the year, select teams, and organize practices or delegate the organization of practices to individual teams.
-    4. The Offensive and Defensive Captains will hold open meetings focused on their respective cybersecurity topics at least three (3) times a semester.
-    5. The Offensive and Defensive Captains must hold tryouts for the CPTC and CCDC competitive teams before the end of September.
-    6. The Captains must have a detailed training plan prior to the start of the semester that must be approved by the President and Vice President.
-    7. The goal of the captain positions will be to gain hands-on leadership experience in a security-focused environment and represent Penn State at various competitive events.
+    3. The CTF Captain will identify and promote CTF competitions throughout the year, select teams, and organize practices or delegate the organization of practices to individual teams. 
+    4. The CTF Captain will organize SillyCTF, an annual public CTF competition, with support from the Executive Board. The CTF Captain may delegate this task.
+    5. The Offensive and Defensive Captains will hold open meetings focused on their respective cybersecurity topics at least three (3) times a semester.
+    6. The Offensive and Defensive Captains must hold tryouts for the CPTC and CCDC competitive teams before the end of September.
+    7. The Captains must have a detailed training plan prior to the start of the semester that must be approved by the President and Vice President.
+    8. The goal of the captain positions will be to gain hands-on leadership experience in a security-focused environment and represent Penn State at various competitive events.
 
 ## 7. Chairs <a name="7-chairs"></a>
 

--- a/constitution.md
+++ b/constitution.md
@@ -92,6 +92,7 @@ election. Officers, captains, and chairs may change from full-time to part-time,
 The organization may establish and apply additional eligibility criteria for
 appointed or elected leaders/officers upon a super-majority (75%) vote.
 * Active members may be elected to officer positions according to the [election](#12-elections) rules in section 12.
+* The 
 * The President may appoint active members to a captain position without a vote with consent from the Vice President.
 * Active members may hold a single officer or captain position at a time.
 * Captains may hold an Officer position with the approval of both the current President and club Advisor.
@@ -170,7 +171,7 @@ efforts and discuss opportunities.
 * In the event an officer steps down, or a position is vacant, the following steps should be taken to replace the
 officer.
   1. The officer stepping down must provide a minimum of two weeks's notice that they are stepping down.
-  2. Upon notice of an officer stepping down, the executive board must begin electing a replacement officer using the [election](#12-elections) rules outlined in section 12.
+  2. Upon notice of an officer stepping down, the Executive Board must begin electing a replacement officer using the [election](#12-elections) rules outlined in section 12.
   3. An interim officer may be appointed by the President and Vice President as needed until the officer position is officially filled
 * In the event an officer is not fulfilling their duties as outlined in [section 5](#5-officers) and by the President, they meet grounds for dismissal from their officer position.
   * The President and Vice President may issue a verbal or written warning outlining the officer in question’s failed duties and other misconducts as applicable.
@@ -193,7 +194,7 @@ officer.
 * For competitions that do not have an associated tryout, captains may use an application form to select their teams.
 * Team captains have the final say over team selection.
 * If a competition has alternate members, the team captain is free to determine the process of selecting both alternates and full members. This process must be made clear up front to all involved team members, ideally at tryouts/application.
-* Captains must confer with the advisor and the highest level executive board member not seeking a spot on the team to confirm their team selections.
+* Captains must confer with the advisor and the highest level Executive Board member not seeking a spot on the team to confirm their team selections.
 * Teams should be selected in a fair manner that emphasizes the skills required to be a successful member of the competition team.
 
 ## 9. Meetings <a name="9-meetings"></a>
@@ -282,4 +283,3 @@ the Executive Board.
 * Responsibilities
   * The Advisor shall serve as an official representative for the Penn State Competitive Cyber Security Organization when required by a competition.
   * The Advisor shall serve as an intermediary between the Penn State Competitive Cyber Security Organization and The Pennsylvania State University or the College of Information Sciences and Technology.
-  

--- a/constitution.md
+++ b/constitution.md
@@ -2,7 +2,7 @@
 
 Date of Origin: September 2014
 
-Last Updated: April 2025
+Last Updated: March 2026
 
 ## Table of Contents
 
@@ -15,8 +15,8 @@ Last Updated: April 2025
 7.  [Removal/Replacement of Officers](#7-removalreplacement-of-officers)
 8.  [Competition Teams](#8-competition-teams)
 9.  [Meetings](#9-meetings)
-10.  [Voting](#10-voting)
-11.  [Finances](#11-finances)
+10. [Voting](#10-voting)
+11. [Finances](#11-finances)
 12. [Elections](#12-elections)
 13. [Amendments to the Constitution](#13-amendments-to-the-constitution)
 14. [Parliamentary Authority](#14-parliamentary-authority)
@@ -27,7 +27,7 @@ Last Updated: April 2025
 
 The purpose of the Penn State Competitive Cyber Security Organization (CCSO) is to
 provide members with opportunities to pursue their interests in all facets of cybersecurity,
-develop their technical skills, collaborate with alumni, and other organizations, and provide
+develop their technical skills, collaborate with alumni and other organizations, and provide
 mentorship opportunities.
 
 ## 2. Mission <a name="2-mission"></a>
@@ -45,7 +45,7 @@ competitions.
 
 * At all times, the majority (50%+1) of all active members shall be full-time, officially
 registered students at University Park.
-* The membership shall be divided into active and associate members
+* The membership shall be divided into active and associate members.
   * Only currently registered students who have paid club dues are eligible for active membership.
   * All other members interested in dedicating themselves to the purpose of the Penn State Competitive Cyber Security Organization, including but not limited to, faculty, students from other Penn State campuses, staff, and community members, shall be associate members.
 * Only active members may hold office, vote, preside, officiate, solicit funds on behalf of
@@ -55,22 +55,22 @@ must be maintained by the organization.
 * The club reserves the right to expel a member who is not following the policies of the
 organization with a super-majority vote (75%) of attending members.
 * In the case of violations of constitutional policies and/or a conflict between members
-within the organization the highest-ranking officer that is not involved in the conflict,
+within the organization, the highest-ranking officer that is not involved in the conflict,
 with assistance from the advisor (if applicable), will facilitate an informal mediation
 procedure:
   * The mediator shall:
-    1. Arrange for a mediation meeting outside of the regular organization business meeting
-    2. Explain their role as the impartial party and the objectives of the mediation
-    3. Set ground rules
-    4. Allow each party to express their views by allowing the conversation to go where the parties wish it to go
-    5. Collect any available resources that might assist in the resolution (financial documents, emails, photos, etc.)
-    6. As a third party, do not suggest resolutions but rather leave the responsibility for the resolution with the parties involved
-    7. Facilitate goal setting to reach a win-win resolution
+    1. Arrange for a mediation meeting outside of the regular organization business meeting.
+    2. Explain their role as the impartial party and the objectives of the mediation.
+    3. Set ground rules.
+    4. Allow each party to express their views by allowing the conversation to go where the parties wish it to go.
+    5. Collect any available resources that might assist in the resolution (financial documents, emails, photos, etc.).
+    6. As a third party, do not suggest resolutions but rather leave the responsibility for the resolution with the parties involved.
+    7. Facilitate goal setting to reach a win-win resolution.
 * New Membership and Recruitment
   * Any new members will be given full disclosure during recruitment, including but not limited to the disclosure of:
-    1. New Membership Manual (if applicable)
-    2. Schedule of New Member Events and Activities (if applicable)
-    3. A list of all responsibilities
+    1. New Membership Manual (if applicable).
+    2. Schedule of New Member Events and Activities (if applicable).
+    3. A list of all responsibilities.
     4. A copy of the University Hazing Policy, prescribed by Policies and Rules for
 Student Organizations. This document is available upon request by the Office of
 Student Activities.
@@ -85,11 +85,11 @@ laws.
 ## 5. Officers <a name="5-officers"></a>
 
 * Undergraduate candidates must be full-time, officially registered active student members
-to be selected as an officer or chair at the time of the appointment or election.
+to be selected as an officer, captain, or chair at the time of the appointment or election.
 Graduate candidates may be full-time or part-time, officially registered active student
-members to be selected as an officer or chair at the time of the appointment or
-election. Officers may change from full-time to part-time, or vice versa, after becoming
-an officer. The organization may establish and apply additional eligibility criteria for
+members to be selected as an officer, captain, or chair at the time of the appointment or
+election. Officers, captains, and chairs may change from full-time to part-time, or vice versa, after starting their role.
+The organization may establish and apply additional eligibility criteria for
 appointed or elected leaders/officers upon a super-majority (75%) vote.
 * Active members may be elected to officer positions according to the [election](#12-elections) rules in section 12.
 * The President may appoint active members to a captain position without a vote with consent from the Vice President.
@@ -172,9 +172,9 @@ officer.
   1. The officer stepping down must provide a minimum of two weeks's notice that they are stepping down.
   2. Upon notice of an officer stepping down, the executive board must begin electing a replacement officer using the [election](#12-elections) rules outlined in section 12.
   3. An interim officer may be appointed by the President and Vice President as needed until the officer position is officially filled
-* In the event an officer is not fulfilling their duties as outlined in [section 5](#5-officers) and by the President. They meet grounds for dismissal from their officer position.
-  * The President and Vice President may issue a verbal or written warning outlining the officer in question’s failed duties and other misconducts as applicable
-  * After a warning is issued. The officer in question will begin a two-week probationary period where they can address the grievances cited in the warning.
+* In the event an officer is not fulfilling their duties as outlined in [section 5](#5-officers) and by the President, they meet grounds for dismissal from their officer position.
+  * The President and Vice President may issue a verbal or written warning outlining the officer in question’s failed duties and other misconducts as applicable.
+  * After a warning is issued, the officer in question will begin a two-week probationary period where they can address the grievances cited in the warning.
   * If after the probationary period, the officer in question is still not meeting the expectations outlined in the warning, the executive board and chairs can vote to remove the officer using a two-thirds majority.
   * If the officer in question believes any part of this proceeding to be unfair or unfounded, these disputes can be discussed with the club advisor.
 
@@ -182,18 +182,18 @@ officer.
 
 ### Tryouts
 
-* The Captains must hold tryouts for the CPTC and CCDC competitive teams before the end of September.
-* Tryouts should consist of a hands-on exercise that provides a fair assessment of skills required to be a successful member of the competition team.
+* The Offensive and Defensive Captains must hold tryouts for the CPTC and CCDC competitive teams before the end of September.
+* Each tryout should consist of a hands-on exercise that provides a fair assessment of skills required to be a successful member of the competition team.
 * Captains may solicit help from other members, alumni, or associate members to build the tryout exercise.
   * If possible, only members not planning to participate in tryouts should assist with the creation of the exercise. Otherwise, another fair evaluation must be provided by the captain for that member.
-* The result of these tryouts may be used to determine the makeup of other competition teams such as Cyberforce. It's encouraged to hold a tryout exercise for all competitions involving travel.
+* The result of these tryouts may be used to determine the makeup of other competition teams, such as CyberForce. It's encouraged to hold a tryout exercise for all competitions involving travel.
 
 ### Team Selection
 
 * For competitions that do not have an associated tryout, captains may use an application form to select their teams.
 * Team captains have the final say over team selection.
 * If a competition has alternate members, the team captain is free to determine the process of selecting both alternates and full members. This process must be made clear up front to all involved team members, ideally at tryouts/application.
-* Captains must confer with the advisor, and the highest level executive board member not seeking a spot on the team to confirm their team selections.
+* Captains must confer with the advisor and the highest level executive board member not seeking a spot on the team to confirm their team selections.
 * Teams should be selected in a fair manner that emphasizes the skills required to be a successful member of the competition team.
 
 ## 9. Meetings <a name="9-meetings"></a>
@@ -226,7 +226,7 @@ active members from voting.
 * This organization will collect reasonable dues if and only if:
   1. The dues are not excessive.
   2. There is a proven need for dues as income for the organization.
-  3. Dues are determined by The Treasurer with consent from the President.
+  3. Dues are determined by the Treasurer with consent from the President.
 * Dues shall be collected semi-annually.
 
 ### Spending
@@ -242,10 +242,9 @@ month prior to the end of the Spring semester.
 * Newly elected officers fully assume their roles and responsibilities at the end of the
 Spring semester.
 * This meeting shall be publicized at least 1 month in advance and in the meetings
-preceding it and through all organizational communication platforms such as Discord,
-and Email.
+preceding it and through all organizational communication platforms such as Discord and email.
 * Election codes
-  1. Nominees for the president must be someone who has held an Officer, Captain, or Chair role in the organization for at least 1 semester. Should no-one meet these criteria, all active members may be nominated.
+  1. Nominees for the role of President must have previously held an Officer, Captain, or Chair role in the organization for at least 1 semester. Should no-one meet these criteria, any active member may be nominated.
   2. All active members may cast a single vote per office.
   3. Any member may nominate an active member for an office prior to the election. Candidates must accept their nomination prior to elections.
   4. Candidates must prepare a brief presentation in support of their candidacy, and answer questions from members.
@@ -283,3 +282,4 @@ the Executive Board.
 * Responsibilities
   * The Advisor shall serve as an official representative for the Penn State Competitive Cyber Security Organization when required by a competition.
   * The Advisor shall serve as an intermediary between the Penn State Competitive Cyber Security Organization and The Pennsylvania State University or the College of Information Sciences and Technology.
+  

--- a/constitution.md
+++ b/constitution.md
@@ -181,8 +181,8 @@ officer or captain.
   1. The officer or captain stepping down must provide a minimum of two weeks's notice that they are stepping down.
   2. Upon notice of an officer stepping down, the Executive Board must begin electing a replacement officer using the rules in the [Elections](#13-elections) section.
   3. Upon notice of a captain stepping down, the Executive Board must appoint a new captain as defined in the [Captains](#6-captains) section.
-  3. An interim officer may be appointed by the President and Vice President as needed until the officer position is officially filled
-* In the event an officer is not fulfilling their duties as outlined in the [Officers](#5-officers) section and by the President, they meet grounds for dismissal from their officer position.
+  4. An interim officer may be appointed by the President and Vice President as needed until the officer position is officially filled
+* In the event an officer or captain is not fulfilling their duties as outlined by the President and in the [Officers](#5-officers) section or the [Captains](#6-captains) section respectively, they meet grounds for dismissal from their officer position.
   * The President and Vice President may issue a verbal or written warning outlining the officer in question’s failed duties and other misconducts as applicable.
   * After a warning is issued, the officer in question will begin a two-week probationary period where they can address the grievances cited in the warning.
   * If after the probationary period, the officer in question is still not meeting the expectations outlined in the warning, the executive board and chairs can vote to remove the officer using a two-thirds majority.

--- a/constitution.md
+++ b/constitution.md
@@ -134,7 +134,7 @@ efforts and discuss opportunities.
 
 ## 6. Captains <a name="6-captains"></a>
 * Active members may be appointed to captain positions by a majority vote of the Executive Board.
-* Following elections and at least one week prior to the end of the Spring semester, the Executive Board shall appoint Offensive, Defensive, and CTF Captains for the upcoming academic year by a majority vote.
+* Following elections and at least one week prior to the end of the Spring semester, the Executive Board shall appoint the Offensive Captain, Defensive Captain, and CTF Captain for the upcoming academic year by a majority vote.
 * The Executive Board shall solicit recommendations for new Captains from the outgoing Captains, and shall also accept statements of interest from active members.
 * Newly appointed captains fully assume their roles and responsibilities at the end of the Spring semester.
 * The President may appoint active members to a captain position without a vote with consent from the Vice President.
@@ -153,7 +153,7 @@ efforts and discuss opportunities.
 
 ## 7. Chairs <a name="7-chairs"></a>
 
-* The President may appoint active members to a chair or captain position without a vote with consent from the Vice President.
+* The President may appoint active members to a chair position without a vote with consent from the Vice President.
 * The President may create, modify, or dismiss chair positions without a vote with consent from the Vice President.
 * There is no limit on the number of chair positions that can be created.
 * There are no restrictions on the number of chair positions a member can hold.

--- a/constitution.md
+++ b/constitution.md
@@ -183,10 +183,10 @@ officer or captain.
   3. Upon notice of a captain stepping down, the Executive Board must appoint a new captain as defined in the [Captains](#6-captains) section.
   4. An interim officer may be appointed by the President and Vice President as needed until the officer position is officially filled
 * In the event an officer or captain is not fulfilling their duties as outlined by the President and in the [Officers](#5-officers) section or the [Captains](#6-captains) section respectively, they meet grounds for dismissal from their officer position.
-  * The President and Vice President may issue a verbal or written warning outlining the officer in question’s failed duties and other misconducts as applicable.
-  * After a warning is issued, the officer in question will begin a two-week probationary period where they can address the grievances cited in the warning.
-  * If after the probationary period, the officer in question is still not meeting the expectations outlined in the warning, the executive board and chairs can vote to remove the officer using a two-thirds majority.
-  * If the officer in question believes any part of this proceeding to be unfair or unfounded, these disputes can be discussed with the club advisor.
+  * The President and Vice President may issue a verbal or written warning outlining the officer or captain in question’s failed duties and other misconducts as applicable.
+  * After a warning is issued, the officer or captain in question will begin a two-week probationary period where they can address the grievances cited in the warning.
+  * If after the probationary period, the officer or captain in question is still not meeting the expectations outlined in the warning, the executive board and chairs can vote to remove the officer or captain using a two-thirds majority.
+  * If the officer or captain in question believes any part of this proceeding to be unfair or unfounded, these disputes can be discussed with the club advisor.
 
 ## 9. Competition Teams <a name="9-competition-teams"></a>
 

--- a/constitution.md
+++ b/constitution.md
@@ -93,10 +93,6 @@ election. Officers, captains, and chairs may change from full-time to part-time,
 The organization may establish and apply additional eligibility criteria for
 appointed or elected leaders/officers upon a super-majority (75%) vote.
 * Active members may be elected to officer positions according to the [election](#13-elections) rules in section 12.
-* Active members may be appointed to captain positions by a majority vote of the Executive Board.
-* The President may appoint active members to a captain position without a vote with consent from the Vice President.
-* Active members may hold a single officer or captain position at a time.
-* Captains may hold an Officer position with the approval of both the current President and club Advisor.
 * The Officers should meet at least once a week when possible. This should include
 captains and chairs for at least a portion of the meeting.
 * The Officers should meet with the advisor at least three (3) times a semester to coordinate
@@ -136,7 +132,13 @@ efforts and discuss opportunities.
     3. The Tech Director will serve as the Webmaster when the position is vacant.
     4. The goal of the Tech Director will be managing and maintaining the technical resources of the club to facilitate trainings, competitions, and club image.
 
-## 6. Captains <a name="7-chairs"></a>
+## 6. Captains <a name="6-captains"></a>
+* Following elections and at least one week prior to the end of the Spring semester, the Executive Board shall appoint Offensive, Defensive, and CTF Captains for the upcoming academic year.
+* Newly appointed captains fully assume their roles and responsibilities at the end of the Spring semester.
+* Active members may be appointed to captain positions by a majority vote of the Executive Board.
+* The President may appoint active members to a captain position without a vote with consent from the Vice President.
+* Active members may hold a single officer or captain position at a time.
+* Captains may hold an Officer position with the approval of both the current President and club Advisor.
 
 * Captain Positions:
   * Offensive, Defensive, and CTF Captains
@@ -148,7 +150,7 @@ efforts and discuss opportunities.
     6. The Captains must have a detailed training plan prior to the start of the semester that must be approved by the President and Vice President.
     7. The goal of the captain positions will be to gain hands-on leadership experience in a security-focused environment and represent Penn State at various competitive events.
 
-## 6. Chairs <a name="7-chairs"></a>
+## 7. Chairs <a name="7-chairs"></a>
 
 * The President may appoint active members to a chair or captain position without a vote with consent from the Vice President.
 * The President may create, modify, or dismiss chair positions without a vote with consent from the Vice President.
@@ -170,7 +172,7 @@ efforts and discuss opportunities.
 * Filling vacancies:
   * If there is a sudden vacancy for an officer position, nominations must be taken at the meeting following the vacancy. Refer to the [election](#13-elections) rules in section 12.
 
-## 7. Removal/Replacement of Officers <a name="8-removalreplacement-of-officers"></a>
+## 8. Removal/Replacement of Officers <a name="8-removalreplacement-of-officers"></a>
 
 * In the event an officer steps down, or a position is vacant, the following steps should be taken to replace the
 officer.

--- a/constitution.md
+++ b/constitution.md
@@ -11,17 +11,18 @@ Last Updated: March 2026
 3.  [Goal](#3-goal)
 4.  [Membership](#4-membership)
 5.  [Officers](#5-officers)
-6.  [Chairs](#6-chairs)
-7.  [Removal/Replacement of Officers](#7-removalreplacement-of-officers)
-8.  [Competition Teams](#8-competition-teams)
-9.  [Meetings](#9-meetings)
-10. [Voting](#10-voting)
-11. [Finances](#11-finances)
-12. [Elections](#12-elections)
-13. [Amendments to the Constitution](#13-amendments-to-the-constitution)
-14. [Parliamentary Authority](#14-parliamentary-authority)
-15. [Accessibility of this Constitution](#15-accessibility-of-this-constitution)
-16. [Advisor](#16-advisor)
+6.  [Captains](#6-captains)
+7.  [Chairs](#7-chairs)
+8.  [Removal/Replacement of Officers](#8-removalreplacement-of-officers)
+9.  [Competition Teams](#9-competition-teams)
+10.  [Meetings](#10-meetings)
+11. [Voting](#11-voting)
+12. [Finances](#12-finances)
+13. [Elections](#13-elections)
+14. [Amendments to the Constitution](#14-amendments-to-the-constitution)
+15. [Parliamentary Authority](#15-parliamentary-authority)
+16. [Accessibility of this Constitution](#16-accessibility-of-this-constitution)
+17. [Advisor](#17-advisor)
 
 ## 1. Purpose <a name="1-purpose"></a>
 
@@ -91,8 +92,8 @@ members to be selected as an officer, captain, or chair at the time of the appoi
 election. Officers, captains, and chairs may change from full-time to part-time, or vice versa, after starting their role.
 The organization may establish and apply additional eligibility criteria for
 appointed or elected leaders/officers upon a super-majority (75%) vote.
-* Active members may be elected to officer positions according to the [election](#12-elections) rules in section 12.
-* The 
+* Active members may be elected to officer positions according to the [election](#13-elections) rules in section 12.
+* Active members may be appointed to captain positions by a majority vote of the Executive Board.
 * The President may appoint active members to a captain position without a vote with consent from the Vice President.
 * Active members may hold a single officer or captain position at a time.
 * Captains may hold an Officer position with the approval of both the current President and club Advisor.
@@ -134,6 +135,9 @@ efforts and discuss opportunities.
     2. The Tech Director will facilitate the technological resources for any club activities.
     3. The Tech Director will serve as the Webmaster when the position is vacant.
     4. The goal of the Tech Director will be managing and maintaining the technical resources of the club to facilitate trainings, competitions, and club image.
+
+## 6. Captains <a name="7-chairs"></a>
+
 * Captain Positions:
   * Offensive, Defensive, and CTF Captains
     1. Each captain position can only be held by one individual, no one may hold multiple captain positions simultaneously.
@@ -144,7 +148,7 @@ efforts and discuss opportunities.
     6. The Captains must have a detailed training plan prior to the start of the semester that must be approved by the President and Vice President.
     7. The goal of the captain positions will be to gain hands-on leadership experience in a security-focused environment and represent Penn State at various competitive events.
 
-## 6. Chairs <a name="6-chairs"></a>
+## 6. Chairs <a name="7-chairs"></a>
 
 * The President may appoint active members to a chair or captain position without a vote with consent from the Vice President.
 * The President may create, modify, or dismiss chair positions without a vote with consent from the Vice President.
@@ -164,14 +168,14 @@ efforts and discuss opportunities.
     1. The Social Chair shall plan, organize, and execute at least 2 social and fundraising events per semester.
     2. The Social Chair will report to the Event Planner unless otherwise decided by the President.
 * Filling vacancies:
-  * If there is a sudden vacancy for an officer position, nominations must be taken at the meeting following the vacancy. Refer to the [election](#12-elections) rules in section 12.
+  * If there is a sudden vacancy for an officer position, nominations must be taken at the meeting following the vacancy. Refer to the [election](#13-elections) rules in section 12.
 
-## 7. Removal/Replacement of Officers <a name="7-removalreplacement-of-officers"></a>
+## 7. Removal/Replacement of Officers <a name="8-removalreplacement-of-officers"></a>
 
 * In the event an officer steps down, or a position is vacant, the following steps should be taken to replace the
 officer.
   1. The officer stepping down must provide a minimum of two weeks's notice that they are stepping down.
-  2. Upon notice of an officer stepping down, the Executive Board must begin electing a replacement officer using the [election](#12-elections) rules outlined in section 12.
+  2. Upon notice of an officer stepping down, the Executive Board must begin electing a replacement officer using the [election](#13-elections) rules outlined in section 12.
   3. An interim officer may be appointed by the President and Vice President as needed until the officer position is officially filled
 * In the event an officer is not fulfilling their duties as outlined in [section 5](#5-officers) and by the President, they meet grounds for dismissal from their officer position.
   * The President and Vice President may issue a verbal or written warning outlining the officer in question’s failed duties and other misconducts as applicable.
@@ -179,7 +183,7 @@ officer.
   * If after the probationary period, the officer in question is still not meeting the expectations outlined in the warning, the executive board and chairs can vote to remove the officer using a two-thirds majority.
   * If the officer in question believes any part of this proceeding to be unfair or unfounded, these disputes can be discussed with the club advisor.
 
-## 8. Competition Teams <a name="8-competition-teams"></a>
+## 9. Competition Teams <a name="9-competition-teams"></a>
 
 ### Tryouts
 
@@ -197,7 +201,7 @@ officer.
 * Captains must confer with the advisor and the highest level Executive Board member not seeking a spot on the team to confirm their team selections.
 * Teams should be selected in a fair manner that emphasizes the skills required to be a successful member of the competition team.
 
-## 9. Meetings <a name="9-meetings"></a>
+## 10. Meetings <a name="10-meetings"></a>
 
 * The Penn State Competitive Cyber Security Organization will meet at least once per
 month
@@ -206,7 +210,7 @@ to all active members.
 * The President, with the consent of the Vice President, may change the meeting frequency.
 * The President may call special meetings at their discretion.
 
-## 10. Voting <a name="10-voting"></a>
+## 11. Voting <a name="11-voting"></a>
 
 * A Quorum for all voting shall be thirty-three percent (33%) of the active members. If an
 active member does not attend four (4) meetings in a row or misses two meetings with
@@ -220,7 +224,7 @@ consent from the Executive Board.
 * The method and format for voting must be reasonable and cannot be used to exclude
 active members from voting.
 
-## 11. Finances <a name="11-finances"></a>
+## 12. Finances <a name="12-finances"></a>
 
 * All organizational funds are to be deposited and handled exclusively through the Associated Student Activities (ASA).
 * This organization will not have an off-campus account(s).
@@ -236,7 +240,7 @@ active members from voting.
 * All other uses of organizational funds require both Treasurer approval and majority consent from the Executive Board.
 * If a dispute about the use of organizational funds cannot be resolved, follow the outlined informal mediation process.
 
-## 12. Elections <a name="12-elections"></a>
+## 13. Elections <a name="13-elections"></a>
 
 * Officer elections shall take place during a regularly scheduled meeting more than a
 month prior to the end of the Spring semester.
@@ -255,7 +259,10 @@ preceding it and through all organizational communication platforms such as Disc
   8. In the event of a tie, the ballots will be recast.
   9. No one involved in conducting the elections may be an official candidate.
 
-## 13. Amendments to the Constitution <a name="13-amendments-to-the-constitution"></a>
+### Selection of Captains and Chairs
+* Captains and chairs are appointed by the 
+
+## 14. Amendments to the Constitution <a name="14-amendments-to-the-constitution"></a>
 
 * Amendments to this constitution may be introduced at any time. Voting must take place at least a week after an amendment's introduction.
 * Any active member can introduce an amendment.
@@ -263,16 +270,16 @@ preceding it and through all organizational communication platforms such as Disc
 * Upon a successful vote, the amendment takes effect following Office of Student Activities approval.
 * The organization's advisor must be notified of proposed constitution changes at least a week in advance and withholds the right to veto constitutional amendments.
 
-## 14. Parliamentary Authority <a name="14-parliamentary-authority"></a>
+## 15. Parliamentary Authority <a name="15-parliamentary-authority"></a>
 
 * Robert’s Rules of Order, Newly Revised, by Sarah Corbin Roberts shall be used in all
 cases not covered by this constitution.
 
-## 15. Accessibility of this Constitution <a name="15-accessibility-of-this-constitution"></a>
+## 16. Accessibility of this Constitution <a name="16-accessibility-of-this-constitution"></a>
 
 * Copies of this constitution shall be made available to anyone upon request.
 
-## 16. Advisor <a name="16-advisor"></a>
+## 17. Advisor <a name="17-advisor"></a>
 
 * This organization must always retain at least one advisor. The advisor will be a full-time
 Faculty or Staff member of The Pennsylvania State University, University Park campus

--- a/constitution.md
+++ b/constitution.md
@@ -13,7 +13,7 @@ Last Updated: March 2026
 5.  [Officers](#5-officers)
 6.  [Captains](#6-captains)
 7.  [Chairs](#7-chairs)
-8.  [Removal/Replacement of Officers](#8-removalreplacement-of-officers)
+8.  [Removal/Replacement of Officers and Captains](#8-removalreplacement-of-officers-and-captains)
 9.  [Competition Teams](#9-competition-teams)
 10.  [Meetings](#10-meetings)
 11. [Voting](#11-voting)
@@ -133,11 +133,12 @@ efforts and discuss opportunities.
     4. The goal of the Tech Director will be managing and maintaining the technical resources of the club to facilitate trainings, competitions, and club image.
 
 ## 6. Captains <a name="6-captains"></a>
-* Active members may be appointed to captain positions by a majority vote of the Executive Board.
 * Following elections and at least one week prior to the end of the Spring semester, the Executive Board shall appoint the Offensive Captain, Defensive Captain, and CTF Captain for the upcoming academic year by a majority vote.
 * The Executive Board shall solicit recommendations for new Captains from the outgoing Captains, and shall also accept statements of interest from active members.
 * Newly appointed captains fully assume their roles and responsibilities at the end of the Spring semester.
-* The President may appoint active members to a captain position without a vote with consent from the Vice President.
+* Active members may be appointed to captain positions by a majority vote of the Executive Board.
+* The President may appoint active members to a vacant captain position without a vote with consent from the Vice President.
+* In the event that a captain is not 
 * Active members may hold a single officer or captain position at a time.
 * Captains may hold an Officer position with the approval of both the current President and club Advisor.
 * Captain Positions:
@@ -173,7 +174,7 @@ efforts and discuss opportunities.
 * Filling vacancies:
   * If there is a sudden vacancy for an officer position, nominations must be taken at the meeting following the vacancy. Refer to the [election](#13-elections) rules in section 12.
 
-## 8. Removal/Replacement of Officers <a name="8-removalreplacement-of-officers"></a>
+## 8. Removal/Replacement of Officers and Captains <a name="8-removalreplacement-of-officers-and-captains"></a>
 
 * In the event an officer steps down, or a position is vacant, the following steps should be taken to replace the
 officer.

--- a/constitution.md
+++ b/constitution.md
@@ -92,7 +92,7 @@ members to be selected as an officer, captain, or chair at the time of the appoi
 election. Officers, captains, and chairs may change from full-time to part-time, or vice versa, after starting their role.
 The organization may establish and apply additional eligibility criteria for
 appointed or elected leaders/officers upon a super-majority (75%) vote.
-* Active members may be elected to officer positions according to the [election](#13-elections) rules in section 13.
+* Active members may be elected to officer positions according to the rules in the [Elections](#13-elections) section.
 * The Officers should meet at least once a week when possible. This should include
 captains and chairs for at least a portion of the meeting.
 * The Officers should meet with the advisor at least three (3) times a semester to coordinate

--- a/constitution.md
+++ b/constitution.md
@@ -92,7 +92,7 @@ members to be selected as an officer, captain, or chair at the time of the appoi
 election. Officers, captains, and chairs may change from full-time to part-time, or vice versa, after starting their role.
 The organization may establish and apply additional eligibility criteria for
 appointed or elected leaders/officers upon a super-majority (75%) vote.
-* Active members may be elected to officer positions according to the [election](#13-elections) rules in section 12.
+* Active members may be elected to officer positions according to the [election](#13-elections) rules in section 13.
 * The Officers should meet at least once a week when possible. This should include
 captains and chairs for at least a portion of the meeting.
 * The Officers should meet with the advisor at least three (3) times a semester to coordinate
@@ -172,16 +172,17 @@ efforts and discuss opportunities.
     1. The Social Chair shall plan, organize, and execute at least 2 social and fundraising events per semester.
     2. The Social Chair will report to the Event Planner unless otherwise decided by the President.
 * Filling vacancies:
-  * If there is a sudden vacancy for an officer position, nominations must be taken at the meeting following the vacancy. Refer to the [election](#13-elections) rules in section 12.
+  * If there is a sudden vacancy for an officer position, nominations must be taken at the meeting following the vacancy. Refer to the rules in the [Elections] section(#13-elections).
 
 ## 8. Removal/Replacement of Officers and Captains <a name="8-removalreplacement-of-officers-and-captains"></a>
 
-* In the event an officer steps down, or a position is vacant, the following steps should be taken to replace the
-officer.
-  1. The officer stepping down must provide a minimum of two weeks's notice that they are stepping down.
-  2. Upon notice of an officer stepping down, the Executive Board must begin electing a replacement officer using the [election](#13-elections) rules outlined in section 12.
+* In the event an officer or captain steps down, or a position is vacant, the following steps should be taken to replace the
+officer or captain.
+  1. The officer or captain stepping down must provide a minimum of two weeks's notice that they are stepping down.
+  2. Upon notice of an officer stepping down, the Executive Board must begin electing a replacement officer using the rules in the [Elections](#13-elections) section.
+  3. Upon notice of a captain stepping down, the Executive Board must appoint a new captain as defined in the [Captains](#6-captains) section.
   3. An interim officer may be appointed by the President and Vice President as needed until the officer position is officially filled
-* In the event an officer is not fulfilling their duties as outlined in [section 5](#5-officers) and by the President, they meet grounds for dismissal from their officer position.
+* In the event an officer is not fulfilling their duties as outlined in the [Officers](#5-officers) section and by the President, they meet grounds for dismissal from their officer position.
   * The President and Vice President may issue a verbal or written warning outlining the officer in question’s failed duties and other misconducts as applicable.
   * After a warning is issued, the officer in question will begin a two-week probationary period where they can address the grievances cited in the warning.
   * If after the probationary period, the officer in question is still not meeting the expectations outlined in the warning, the executive board and chairs can vote to remove the officer using a two-thirds majority.


### PR DESCRIPTION
Constitution Amendment
- Added a Captain section, moved Captain definitions from the Officers section to the Captains section
- Added SillyCTF as an annual responsibility of the CTF Captain (can be delegated)
- Clarified the existing officer Removal/Replacement section to cover Captain roles
- Defined Captain selection (majority vote by Executive Board after elections annually)
- Miscellaneous proofreading fixes, changed some static section references to make it easier to add new sections in the future